### PR TITLE
docs: fix case-sensitive Harbor dataset URL in citation

### DIFF
--- a/README.md
+++ b/README.md
@@ -308,7 +308,7 @@ We've run these benchmarks against DevRev Computer and Claude Code. See the jobs
   title={Enterprise-Bench: An Open Benchmark for Enterprise AI Agents},
   author={Smith, Jeff and DevRev Office of the CTO},
   year={2026},
-  url={https://hub.harborframework.com/datasets/enterprise-bench/l1-l2-bench}
+  url={https://hub.harborframework.com/datasets/Enterprise-Bench/l1-l2-bench}
 }
 ```
 


### PR DESCRIPTION
## Summary
The Harbor Hub dataset URL is **case-sensitive**. The BibTeX citation block in the README used the lowercase path, which returns a 404:

- Broken: `https://hub.harborframework.com/datasets/enterprise-bench/l1-l2-bench`
- Correct: `https://hub.harborframework.com/datasets/Enterprise-Bench/l1-l2-bench`

This one-line fix corrects the citation URL so anyone copying the BibTeX to cite Enterprise-Bench gets a link that actually resolves.

## Change
- `README.md` (line 311): `enterprise-bench` → `Enterprise-Bench` in the citation `url` field.

## Notes
- This was the only occurrence of the mis-cased dataset URL in the repo (leaderboard entries reference the dataset differently).