### PR TITLE
Intent: Claude Code + Claude Sonnet 5

### DIFF
--- a/intents/nkthakur48.md
+++ b/intents/nkthakur48.md
@@ -1,0 +1,25 @@
+# Intent: Claude Code + Claude Sonnet 5
+
+- **Submitted by:** nkthakur48
+- **Contact (optional):** nthakur@adobe.com
+
+## Harness
+- **Name / framework:** Claude Code
+- **Link:** https://claude.com/claude-code
+- **Runs on Harbor?** Yes — built-in agent (`-a claude-code`, per README)
+
+## Model
+- **LLM:** Claude Sonnet 5 (`claude-sonnet-5`)
+- **Access:** API (Anthropic direct API)
+
+## Why this combination
+Claude Code already has a submission in flight for Opus 5 (PR #14, 82.86%), but no Sonnet 5
+data point exists yet on the same harness. Sonnet 5 is the mid-tier model in the same
+generation — this fills out the cost/accuracy comparison within one model family rather than
+just across harnesses.
+
+## Help wanted
+- [ ] Setting up the harness to run against Enterprise-Bench
+- [ ] Model / gateway access
+- [ ] Interpreting or submitting results
+- [x] Nothing — I just want it on the roadmap

--- a/intents/nkthakur48.md
+++ b/intents/nkthakur48.md
@@ -23,3 +23,6 @@ just across harnesses.
 - [x] Model / gateway access
 - [x] Interpreting or submitting results
 - [ ] Nothing — I just want it on the roadmap
+
+## Notes
+This is an Intent submission only. It requests a reproducible benchmark run; it does not claim completed results.

--- a/intents/nkthakur48.md
+++ b/intents/nkthakur48.md
@@ -19,7 +19,7 @@ generation — this fills out the cost/accuracy comparison within one model fami
 just across harnesses.
 
 ## Help wanted
-- [ ] Setting up the harness to run against Enterprise-Bench
-- [ ] Model / gateway access
-- [ ] Interpreting or submitting results
-- [x] Nothing — I just want it on the roadmap
+- [x] Setting up the harness to run against Enterprise-Bench
+- [x] Model / gateway access
+- [x] Interpreting or submitting results
+- [ ] Nothing — I just want it on the roadmap

--- a/intents/nkthakur48.md
+++ b/intents/nkthakur48.md
@@ -1,7 +1,7 @@
 # Intent: Claude Code + Claude Sonnet 5
 
 - **Submitted by:** nkthakur48
-- **Contact (optional):** nthakur@adobe.com
+- **Contact (optional):** nishant.thakur.ece@gmail.com
 
 ## Harness
 - **Name / framework:** Claude Code


### PR DESCRIPTION
## Intent: put this harness + model on the leaderboard

**Your name / handle:** nkthakur48
**Contact (optional):**

## Harness

- **Harness / framework:** Claude Code
- **Link (repo or docs):** https://claude.com/claude-code
- **Runs on Harbor?** Yes — built-in agent (`-a claude-code`, per README)

## Model

- **LLM you want evaluated:** Claude Sonnet 5 (`claude-sonnet-5`)
- **Access:** API (Anthropic direct API)

## Why this combination

Claude Code already has a submission in flight for Opus 5 (#14, 82.86%), but no Sonnet 5 data point exists yet on the same harness. This fills out the cost/accuracy comparison within one model generation rather than just across harnesses.

## What you'd like help with

- [x] Setting up the harness to run against Enterprise-Bench
- [x] Model / gateway access
- [x] Interpreting or submitting results

## Checklist

- [x] I added a single entry under `intents/` (no benchmark run required to open this PR)
- [x] I'm open to the maintainers reaching out to help with setup

## Notes
This is an Intent submission only. It requests a reproducible benchmark run; it does not claim completed results.