### PR TITLE
Intent: OpenCode + Mistral Large 3

### DIFF
--- a/intents/rounakbhowal2.md
+++ b/intents/rounakbhowal2.md
@@ -1,0 +1,17 @@
+# Intent: OpenCode + Mistral Large 3
+
+- **Submitted by:** rounakbhowal2
+- **Contact (optional):** via GitHub
+
+## Harness
+- **Name / framework:** OpenCode — open-source, provider-agnostic terminal coding agent with native MCP support.
+- **Link:** https://opencode.ai
+- **Runs on Harbor?** not sure — not currently a Harbor built-in agent (`claude-code`, `aider`, `codex`, `copilot-cli`, `cursor-cli`, `cline-cli` are); would likely need a custom agent import path (`-a my_agents.custom:MyAgent`) pointed at OpenCode's MCP client.
+
+## Model
+- **LLM:** Mistral Large 3 (Mistral AI)
+- **Access:** API (La Plateforme) — open-weight license tier may also allow self-hosted eval; flagging both in case gateway access is a blocker.
+
+## Why this combination
+
+Every model currently on the leaderboard comes from a lab with heavy mainstream mindshare (Anthropic, OpenAI, xAI, Z.ai, DeepSeek, Moonshot). Mistral is a notable gap: it scores competitively on public coding/reasoning benchmarks but is rarely evaluated on enterprise-agent workflows specifically, and its cost-per-token is substantially lower than the Opus/GPT/Grok entries already here. Enterprise-Bench's own headline finding is that *tool-interface architecture* predicts production performance better than model choice — this pairing is a direct test of that claim on a model most people assume is "good but not frontier." Pairing it with OpenCode (rather than a heavyweight vendor harness) keeps the tool-interface layer lightweight too, so a strong result would say something about the model itself rather than an unusually sophisticated harness carrying it.


### PR DESCRIPTION
## Summary

Intent PR for the Enterprise-Bench Challenge — requesting **Mistral Large 3** (Mistral AI) on the leaderboard via the **OpenCode** harness. 

No benchmark run is attached. Per the challenge Intent PR path, this signals a harness + model combination for a maintainer to help set up and run. OpenCode is not currently a Harbor built-in agent, so this may also need a custom-agent wiring step.

## Type of contribution
- Intent PR

