### PR TITLE
Intent: LangGraph + Claude Sonnet 5

### DIFF
--- a/intents/Baibhab97.md
+++ b/intents/Baibhab97.md
@@ -1,0 +1,28 @@
+Intent: put this harness + model on the leaderboard
+
+Your name / handle: Baibhab97
+Contact: via GitHub
+
+## Harness
+
+- **Harness / framework:** LangGraph
+- **Link (repo or docs):** https://github.com/langchain-ai/langgraph
+- **Runs on Harbor?** To be confirmed with maintainers
+
+## Model
+
+- **LLM you want evaluated:** Claude Sonnet 5 (Anthropic)
+- **Access:** API
+
+## Why this combination
+
+LangGraph's graph-based orchestration suits the multi-step, cross-system reasoning that Enterprise-Bench tasks require. Claude Sonnet 5 has strong tool-use and long-horizon agentic performance, making it a good fit for L2/L3 tasks involving ambiguity handling, permission awareness, and durable, verifiable end-states.
+
+## What you'd like help with
+
+- [x] Nothing — I just want it on the roadmap
+
+## Checklist
+
+- [x] I added a single entry under "intents/" (no benchmark run required to open this PR)
+- [x] I'm open to the maintainers reaching out to help with setup


### PR DESCRIPTION
## Summary

Intent PR for the Enterprise-Bench Challenge — requesting Claude Sonnet 5 (Anthropic) on the leaderboard via the LangGraph harness. See `intents/Baibhab97.md` for full details.

No benchmark run is attached. Per the challenge Intent PR path, this signals a harness + model combination for a maintainer to help set up and run.